### PR TITLE
Added an option to chose if you want to compare item components when trading

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,6 @@ This mod can be configured in-game using Mod Menu or by editing the configuratio
 - **ticksBetweenActions**: Number of ticks between actions (Default: `1`, Min: `0.025`).
 - **autofillBehavior**: How to autofill the trade (Default: `DEFAULT`, Options: `DEFAULT`, `STRICT`).
 - **tradeBlockBehavior**: When to block speed trading (Default: `DAMAGEABLE`, Options: `DAMAGEABLE`, `UNSTACKABLE`, `DISABLED`).
+- **compareItemComponents**: Compares items components when checking for similar items in the inventory (Default: `true`).
 
 This is an updated fork of [SpeedTrading](https://github.com/ModsByLeo/SpeedTrading) by [ModsByLeo](https://github.com/ModsByLeo). Full credit goes to them for creating it.

--- a/src/main/java/io/bendy1234/fasttrading/config/ModConfig.java
+++ b/src/main/java/io/bendy1234/fasttrading/config/ModConfig.java
@@ -9,4 +9,6 @@ public class ModConfig extends MidnightConfig {
     public static AutofillBehavior autofillBehavior = AutofillBehavior.DEFAULT;
     @Entry
     public static TradeBlockBehavior tradeBlockBehavior = TradeBlockBehavior.DAMAGEABLE;
+    @Entry
+    public static boolean compareItemComponents = true;
 }

--- a/src/main/java/io/bendy1234/fasttrading/gui/SpeedTradeButton.java
+++ b/src/main/java/io/bendy1234/fasttrading/gui/SpeedTradeButton.java
@@ -34,6 +34,7 @@ public class SpeedTradeButton extends AbstractButton {
     private static final Style STYLE_GRAY = Style.EMPTY.withColor(ChatFormatting.GRAY);
     private final MerchantScreenHooks hooks;
     private Phase phase;
+    private MerchantOffer actionTradeOffer;
 
     public SpeedTradeButton(int x, int y, MerchantScreenHooks hooks) {
         super(x, y, 18, 20, Component.empty());
@@ -52,12 +53,14 @@ public class SpeedTradeButton extends AbstractButton {
     public void onPress(InputWithModifiers input) {
         if (checkPrimed()) {
             phase = Phase.AUTOFILL;
+            actionTradeOffer = hooks.fasttrading$getCurrentTradeOffer();
             SpeedTradeTimer.start();
         }
     }
 
+    //checks if the player still has items to trade and if he didn't change trade
     private boolean checkState() {
-        if (hooks.fasttrading$computeState() != MerchantScreenHooks.State.CAN_PERFORM) {
+        if (hooks.fasttrading$computeState() != MerchantScreenHooks.State.CAN_PERFORM || actionTradeOffer != hooks.fasttrading$getCurrentTradeOffer()) {
             phase = Phase.INACTIVE;
             hooks.fasttrading$clearSellSlots();
             SpeedTradeTimer.stop();

--- a/src/main/java/io/bendy1234/fasttrading/mixin/MerchantScreenMixin.java
+++ b/src/main/java/io/bendy1234/fasttrading/mixin/MerchantScreenMixin.java
@@ -124,8 +124,15 @@ public abstract class MerchantScreenMixin extends AbstractContainerScreen<Mercha
         int count = 0;
         for (int i = 3; i < 39; i++) {
             ItemStack invstack = menu.getSlot(i).getItem();
-            if (!ItemStack.isSameItemSameComponents(item, invstack)) {
-                continue;
+            if (ModConfig.compareItemComponents){
+                if (!ItemStack.isSameItemSameComponents(item, invstack)) {
+                    continue;
+                }
+            }
+            else{
+                if (!ItemStack.isSameItem(item, invstack)) {
+                    continue;
+                }
             }
 
             count += invstack.getCount();

--- a/src/main/java/io/bendy1234/fasttrading/util/PlayerInventoryUtil.java
+++ b/src/main/java/io/bendy1234/fasttrading/util/PlayerInventoryUtil.java
@@ -1,5 +1,6 @@
 package io.bendy1234.fasttrading.util;
 
+import io.bendy1234.fasttrading.config.ModConfig;
 import net.minecraft.core.NonNullList;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.item.ItemStack;
@@ -7,7 +8,10 @@ import net.minecraft.world.item.trading.MerchantOffer;
 
 public class PlayerInventoryUtil {
     public static boolean areItemsEqual(ItemStack a, ItemStack b) {
-        return ItemStack.isSameItemSameComponents(a, b);
+        if(ModConfig.compareItemComponents){
+            return ItemStack.isSameItemSameComponents(a, b);
+        }
+        return ItemStack.isSameItem(a, b);
     }
 
     public static boolean listContainsStack(NonNullList<ItemStack> list, ItemStack stack) {

--- a/src/main/resources/assets/fasttrading/lang/en_us.json
+++ b/src/main/resources/assets/fasttrading/lang/en_us.json
@@ -28,6 +28,6 @@
   "fasttrading.midnightconfig.enum.TradeBlockBehavior.DAMAGEABLE": "Result is Damageable",
   "fasttrading.midnightconfig.enum.TradeBlockBehavior.UNSTACKABLE": "Result is Unstackable",
   "fasttrading.midnightconfig.enum.TradeBlockBehavior.DISABLED": "Disabled",
-  "fasttrading.midnightconfig.compareItemComponents": "Compare Items Components",
+  "fasttrading.midnightconfig.compareItemComponents": "Compare Item Components",
   "fasttrading.midnightconfig.compareItemComponents.tooltip": "Compares items components (name, nbt...) when checking for similar items in the inventory.\nWhen disabled, it only compares the item type."
 }

--- a/src/main/resources/assets/fasttrading/lang/en_us.json
+++ b/src/main/resources/assets/fasttrading/lang/en_us.json
@@ -27,5 +27,7 @@
   "fasttrading.midnightconfig.tradeBlockBehavior.tooltip": "Controls when to not allow speed trading.",
   "fasttrading.midnightconfig.enum.TradeBlockBehavior.DAMAGEABLE": "Result is Damageable",
   "fasttrading.midnightconfig.enum.TradeBlockBehavior.UNSTACKABLE": "Result is Unstackable",
-  "fasttrading.midnightconfig.enum.TradeBlockBehavior.DISABLED": "Disabled"
+  "fasttrading.midnightconfig.enum.TradeBlockBehavior.DISABLED": "Disabled",
+  "fasttrading.midnightconfig.compareItemComponents": "Compare Items Components",
+  "fasttrading.midnightconfig.compareItemComponents.tooltip": "Compares items components (name, nbt...) when checking for similar items in the inventory.\nWhen disabled, it only compares the item type."
 }


### PR DESCRIPTION
This option is useful when you want to trade items that are renamed. This is can happen if a player has renamed the item with an anvil, but also some servers change items name on the client side (new name or adding a color...) and it prevented the auto-trading button from working.

When enabled, it works the same as it used to. 
When disabled, it will now only look for the same item type.